### PR TITLE
fix: open the correct dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "github-gifs",
+  "name": "gitlab-gifs",
   "type": "module",
-  "version": "1.2.11",
+  "version": "1.0.0",
   "private": true,
   "description": "A browser extension that adds GIF support to GitLab comments",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -128,7 +128,7 @@ function addToolbarButton(toolbar) {
   const giphyToolbarItems = select.all(giphyToolbarItemSelector, toolbar);
 
   if (giphyToolbarItems.length > 0) {
-    console.log('Giphy toolbar item already added');
+    debugLog('Giphy toolbar item already added');
     return;
   }
 
@@ -248,7 +248,7 @@ function listen() {
     const dropdown = form ? form.querySelector('#base-dropdown-68') : undefined;
 
     if (!dropdown) {
-      console.debug('No dropdown found');
+      debugLog('No dropdown found');
       return;
     }
 
@@ -309,7 +309,6 @@ function init() {
 
   // Watch for new toolbars
   observe(toolbarSelector, (toolbar) => {
-    console.log('New toolbar detected:', toolbar);
     debugLog('New toolbar detected:', toolbar);
     addToolbarButton(toolbar);
   });

--- a/src/main.js
+++ b/src/main.js
@@ -125,10 +125,10 @@ function addToolbarButton(toolbar) {
   }
 
   const giphyToolbarItemSelector = '[data-testid="giphy-toolbar-item"]';
-  const giphyToolbarItems = select.all(giphyToolbarItemSelector);
+  const giphyToolbarItems = select.all(giphyToolbarItemSelector, toolbar);
 
-  // Skip if we've already added a button to this toolbar
   if (giphyToolbarItems.length > 0) {
+    console.log('Giphy toolbar item already added');
     return;
   }
 
@@ -186,7 +186,7 @@ function addToolbarButton(toolbar) {
   );
 
   // Add the button at the appropriate position
-  toolbar.before(button);
+  toolbar.insertBefore(button, toolbar.firstChild);
 
   // Mark the toolbar and form as processed
   toolbar.classList.add('gl-has-giphy-button');
@@ -239,41 +239,43 @@ function listen() {
     preventFormSubmitOnEnter,
   );
 
-  // Manejar el toggle del dropdown cuando se hace clic en el botón
   delegate('#dropdown-toggle-btn-66', 'click', (event) => {
     event.preventDefault();
     event.stopPropagation();
 
     const button = event.delegateTarget;
-    const dropdown = document.querySelector('#base-dropdown-68');
+    const form = button.closest('.gl-has-giphy-field');
+    const dropdown = form ? form.querySelector('#base-dropdown-68') : undefined;
 
-    if (!dropdown)
+    if (!dropdown) {
+      console.debug('No dropdown found');
       return;
+    }
 
     const isExpanded = button.getAttribute('aria-expanded') === 'true';
 
-    // Cambiar el estado
     button.setAttribute('aria-expanded', !isExpanded);
     dropdown.style.visibility = isExpanded ? 'hidden' : 'visible';
 
     if (!isExpanded) {
-      // Si estamos mostrando el dropdown, inicializar
       watchGiphyModals(button);
     }
   });
 
-  // Cerrar dropdown al hacer clic fuera
   document.addEventListener('click', (event) => {
-    const dropdown = document.querySelector('#base-dropdown-68');
-    const button = document.querySelector('#dropdown-toggle-btn-66');
+    const activeButtons = select.all('#dropdown-toggle-btn-66[aria-expanded="true"]');
 
-    if (!dropdown || !button)
-      return;
+    for (const button of activeButtons) {
+      const form = button.closest('.gl-has-giphy-field');
+      const dropdown = form ? form.querySelector('#base-dropdown-68') : undefined;
 
-    // Si el clic no fue dentro del dropdown ni en el botón
-    if (!dropdown.contains(event.target) && event.target !== button) {
-      dropdown.style.visibility = 'hidden';
-      button.setAttribute('aria-expanded', 'false');
+      if (!dropdown)
+        continue;
+
+      if (!dropdown.contains(event.target) && event.target !== button) {
+        dropdown.style.visibility = 'hidden';
+        button.setAttribute('aria-expanded', 'false');
+      }
     }
   });
 }
@@ -293,7 +295,7 @@ function init() {
 
   // Add buttons to existing toolbars
   // Use a selector that matches both new and old GitHub styles
-  const toolbarSelector = '[aria-label="Go full screen"]';
+  const toolbarSelector = '[class*="full-screen gl-flex"]';
   const existingToolbars = select.all(toolbarSelector);
   debugLog('Found existing toolbars:', existingToolbars.length);
 
@@ -341,11 +343,9 @@ function resetGiphyModals() {
       resultContainer.dataset.hasResults = false;
     }
 
-    // Ocultar el dropdown
     dropdown.style.visibility = 'hidden';
   }
 
-  // Resetear estados de botones
   for (const button of buttons) {
     button.setAttribute('aria-expanded', 'false');
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/chrome-manifest",
   "manifest_version": 3,
   "name": "GIFs for GitLab",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Easily search GIPHY to add a GIF into any GitLab comment box.",
   "action": {
     "default_icon": {


### PR DESCRIPTION
When opening the dropdown doing a gitlab code review it could happen that the button did not opened because it was looking for the first dropdown that the code has (in gitlab you can have multiple toolbars in the same page).